### PR TITLE
Use upstream ksni

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "dbus-codegen"
-version = "0.11.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd91775d91fc83c7d526aa7c08078bac0b30f382706689901ac819fe6ddc812"
+checksum = "a49da9fdfbe872d4841d56605dc42efa5e6ca3291299b87f44e1cde91a28617c"
 dependencies = [
  "clap",
  "dbus",
@@ -75,22 +75,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "dbus_hooks"
-version = "0.2.2"
-dependencies = [
- "dbus",
- "dbus-codegen",
- "dbus-tree",
- "thiserror",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ksni"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4934310bdd016e55725482b8d35ac0c16fd058c1b955d8959aa2d953b918c85b"
+dependencies = [
+ "dbus",
+ "dbus-codegen",
+ "dbus-tree",
+ "thiserror",
 ]
 
 [[package]]
@@ -112,7 +114,7 @@ dependencies = [
 name = "linux-sys-tray"
 version = "0.1.0"
 dependencies = [
- "dbus_hooks",
+ "ksni",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dbus_hooks = { git = "https://github.com/thunderbird/dbus_hooks.git", version = "0.2.2" }
+ksni = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,31 @@ impl ksni::Tray for MyTray {
     fn id(&self) -> String {
         env!("CARGO_PKG_NAME").into()
     }
+    fn icon_theme_path(&self) -> String {
+        let mut assets_dir = env::current_dir().expect("error");
+        assets_dir.push("assets");
+        assets_dir.display().to_string().into()
+    }
+    fn icon_name(&self) -> String {
+        let my_de = env::var("XDG_CURRENT_DESKTOP").expect("error");
+        let mut preferred_icon = "Thunderbird.svg";
+        if my_de
+            .replace(":", ";")
+            .split(";")
+            .map(|m| m.to_ascii_lowercase())
+            .any(|e| &e == "gnome")
+        {
+            preferred_icon = "tb-symbolic-white.svg";
+        } else if my_de
+            .replace(":", ";")
+            .split(";")
+            .map(|m| m.to_ascii_lowercase())
+            .any(|e| &e == "kde")
+        {
+            preferred_icon = "Thunderbird_Logo_Outline-Light.svg";
+        }
+        preferred_icon.into()
+    }
     fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
         use ksni::menu::*;
         vec![StandardItem {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ impl ksni::Tray for MyTray {
         assets_dir.display().to_string().into()
     }
     fn icon_name(&self) -> String {
-        let my_de = env::var("XDG_CURRENT_DESKTOP").expect("error");
+        let my_de = env::var("XDG_CURRENT_DESKTOP").expect("Error - no detected Linux desktop");
         let mut preferred_icon = "Thunderbird.svg";
         if my_de
             .replace(":", ";")

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ struct MyTray {
     checked: bool,
 }
 
-impl dbus_hooks::Tray for MyTray {
+impl ksni::Tray for MyTray {
     fn title(&self) -> String {
         if self.checked { "Thunderbird" } else { "MyTray" }.into()
     }
@@ -15,8 +15,8 @@ impl dbus_hooks::Tray for MyTray {
     fn id(&self) -> String {
         env!("CARGO_PKG_NAME").into()
     }
-    fn menu(&self) -> Vec<dbus_hooks::MenuItem<Self>> {
-        use dbus_hooks::menu::*;
+    fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
+        use ksni::menu::*;
         vec![StandardItem {
             label: "Exit".into(),
             icon_name: "application-exit".into(),
@@ -28,7 +28,7 @@ impl dbus_hooks::Tray for MyTray {
 }
 
 fn main() {
-    let service = dbus_hooks::TrayService::new(MyTray {
+    let service = ksni::TrayService::new(MyTray {
         //selected_option: 0,
         checked: false,
     });


### PR DESCRIPTION
Hi :wave:, author of ksni here. Just found this project and noticed it forked ksni to custom the tray properties, but that's unnecessary, the default implementation of trait in Rust can be overridden, see https://doc.rust-lang.org/book/ch10-02-traits.html#default-implementations, and that's why [the assertion](https://github.com/thunderbird/dbus_hooks/commit/b541db175fb145d976e9376a2a7f18b8f03d7f23) fail (the default behavior changed).

I recently released ksni 0.3, it removed the dependency on libdbus, but requires Rust 1.80, which may be a problem to packagers in some distro, so I kept 0.2 here